### PR TITLE
[WIP] Fix `deploy-staging`: staging app should connect to staging API

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,13 @@
       ],
       "plugins": ["transform-object-rest-spread"]
     },
+    "staging": {
+      "presets": [
+        ["es2015", { "modules": false }],
+        "react"
+      ],
+      "plugins": ["transform-object-rest-spread"]
+    },
     "test": {
       "presets": ["es2015", "react"],
       "plugins": ["transform-object-rest-spread"]

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
     "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "deploy-staging": "export NODE_ENV=staging; npm run build && publisssh dist zooniverse-static/preview.zooniverse.org/classroom",
-    "deploy-production": "export NODE_ENV=production; npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
+    "deploy-production": "export NODE_ENV=production; npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org",
+    "build-staging": "export NODE_ENV=staging; export BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.staging.config.js && echo NODE_ENV is $NODE_ENV",
+    "deploy-staging": "export NODE_ENV=staging; npm run build-staging && publisssh dist zooniverse-static/preview.zooniverse.org/classroom"
   },
   "engines": {
     "node": ">=8.1.2",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -59,6 +59,15 @@ const baseConfig = {
   }
 };
 
+// DEBUG
+console.log('DEBUG...')
+console.log('-'.repeat(80))
+console.log('env: ', env)
+console.log('envFromBrowser: ', envFromBrowser)
+console.log('envFromShell: ', envFromShell)
+console.log('DEFAULT_ENV: ', DEFAULT_ENV)
+console.log('-'.repeat(80))
+
 const config = baseConfig[env];
 export { env, config };
 

--- a/webpack.staging.config.js
+++ b/webpack.staging.config.js
@@ -1,0 +1,90 @@
+/* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true  }] */
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const StatsPlugin = require('stats-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const nib = require('nib');
+
+module.exports = {
+  mode: 'none',  //It's either 'production', 'development', or 'none'. No 'staging' for you.
+  entry: [
+    path.join(__dirname, 'src/index.jsx'),
+  ],
+
+  output: {
+    path: path.join(__dirname, '/dist/'),
+    filename: '[name]-[hash].min.js',
+  },
+
+  plugins: [
+    new CleanWebpackPlugin(['dist']),
+    new HtmlWebpackPlugin({
+      template: 'src/index.tpl.html',
+      inject: 'body',
+      filename: 'index.html',
+      gtm: '<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WDW6V4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="//www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-WDW6V4");</script>',
+    }),
+    new ExtractTextPlugin({
+      filename: '[name]-[hash].min.css',
+      allChunks: true,
+    }),
+    new StatsPlugin('webpack.stats.json', {
+      source: false,
+      modules: false,
+    }),
+    new CopyWebpackPlugin([
+      { from: 'src/images', to: 'images' }
+    ]),
+  ],
+
+  resolve: {
+    extensions: ['.js', '.jsx', '.styl', '.css', '.json'],
+    modules: ['.', 'node_modules'],
+  },
+
+  module: {
+    rules: [{
+      test: /\.jsx?$/,
+      exclude: /node_modules/,
+      use: 'babel-loader',
+    }, {
+      test: /\.css$/,
+      use: ['style-loader', {
+        loader: 'css-loader',
+        options: {
+          includePaths: [
+            path.resolve(__dirname, 'node_modules/zoo-grommet/dist'),
+            path.resolve(__dirname, 'node_modules/zooniverse-react-components/lib')
+          ]
+        }
+      }]
+    }, {
+      test: /\.styl$/,
+      use: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: [{
+          loader: 'css-loader',
+        }, {
+          loader: 'stylus-loader',
+          options: {
+            use: [nib()],
+          },
+        }],
+      }),
+    }, {
+      test: /\.(jpg|png|gif|otf|eot|svg|ttf|woff\d?)$/,
+      use: [{
+        loader: 'file-loader',
+      }, {
+        loader: 'image-webpack-loader',
+      }],
+    }],
+  },
+
+  node: {
+    fs: 'empty'
+  }
+};


### PR DESCRIPTION
## PR Overview

This PR (attempts to) fix `npm run deploy-staging`, because at the moment it's building and deploying the app to `http://classroom.preview.zooniverse.org/` with _production_ specs instead of _staging_ specs. This results in unexpected behaviour, where users login with their proper Zooniverse accounts instead of their staging accounts.

Tagging @srallen and @camallen for an FYI.

### Dev Notes

- Main problem was that `npm run deploy-staging` was using the same `build` command as `deploy-production`, and that build command is hardcoded to run production specs.
- So far I've managed to split `deploy-staging` so it has its own `build-staging` command, and corresponding `webpack.staging.config`.
- Current issue I'm troubleshooting is that the webpack config file keeps overriding the NODE_ENV variable based on its `mode`, which is either 'production' (which is the default, and takes place if 'mode' isn't specified), 'development', or 'none'... and using 'none' actually sets NODE_ENV=none, which breaks the Panoptes JavaScript Client.
- Sarah pointed out that for our other projects, the solution for specifying our own ENV variables is to use `DefinePlugin`, so that's what I'm going to try next.

### Status

DEBUG MODE! WIP! DO NOT MERGE YET