### PR TITLE
Change name to Zooniverse Classroom + Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Education API Front End (Zooniverse Classroom)
+# Zooniverse Classrooms
 
-The Education API Front End (also known as the Zooniverse Classrooms, for
-reasons that will become obvious) is the [Zooniverse's](https://www.zooniverse.org/)
-web portal for educational tools, designed for Teachers and Students who want to
-learn more about science using real world people-powered research projects.
+Zooniverse Classrooms (formerly Education API Front End, or edu-api-front-end)
+is the [Zooniverse's](https://www.zooniverse.org/) web portal for educational
+tools, designed for Teachers and Students who want to learn more about science
+using real world people-powered research projects.
 
 The website is available at [https://classroom.zooniverse.org/](https://classroom.zooniverse.org/)
 

--- a/docs/wildcam/README.md
+++ b/docs/wildcam/README.md
@@ -7,8 +7,7 @@ Prepared by
 @shaun.a.noordin 2018.07.24
 
 For use with
-[WildCam Darien Lab](https://github.com/zooniverse/edu-api-front-end),
-WildCam Gorongosa Lab (https://github.com/zooniverse/wildcam-gorongosa-education)
+[WildCam Gorongosa & Darien Lab](https://github.com/zooniverse/classroom)
 and the [Carto](https://wildcam-darien.carto.com/) map database.
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "edu-api-front-end",
+  "name": "classroom",
   "version": "1.1.0",
-  "description": "Education API front-end application",
+  "description": "Zooniverse Classrooms is the Zooniverse's web portal for educational tools, designed for Teachers and Students who want to learn more about science using real world people-powered research projects.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zooniverse/edu-api-front-end"
+    "url": "https://github.com/zooniverse/classroom"
   },
   "scripts": {
     "start": "export NODE_ENV=development; BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
@@ -15,15 +15,15 @@
     "deploy-production": "export NODE_ENV=production; npm run build && node ./bin/upload.js dist classroom.zooniverse.org"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/zooniverse/edu-api-front-end"
+    "url": "https://github.com/zooniverse/classroom"
   },
-  "homepage": "https://github.com/zooniverse/edu-api-front-end",
+  "homepage": "https://github.com/zooniverse/classroom",
   "dependencies": {
     "browser-filesaver": "1.1.1",
     "classnames": "~2.2.5",


### PR DESCRIPTION
## PR Overview

This repo was recently renamed from `edu-api-front-end` (Education API Front End) to `classroom` (to properly reflect its actual branding of Zooniverse Classrooms). This PR changes several name references to reflect that.

- Updated `package.json` and a few `README`s
- Update required node version to >= 14

### Status

One sec, gonna wipe then reinstall packages to test out Node 14.