### PR TITLE
WildCam: discard Carto, use Datasette

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Depends on [docker install](https://docs.docker.com/install/) and [docker-compos
 2. `docker-compose up`
 
 Or get a bash console where you can run `npm` cmds via the built container (ensure step 1 above is done)
-`docker-compose run --rm --service-ports --entrypoint="bash" classrooms`
+`docker-compose run --rm --service-ports classrooms bash`
 
 Run the tests via docker
-`docker-compose run --rm --entrypoint="npm run test" classrooms`
+`docker-compose run --rm classrooms npm run test`
 
 ## External Dependencies
 

--- a/src/modules/wildcam-map/ducks/index.js
+++ b/src/modules/wildcam-map/ducks/index.js
@@ -353,17 +353,7 @@ Effect('wcm_getActiveCamera', (payload = {}) => {
   })
   .then(json => {
     Actions.wildcamMap.setActiveCameraDataStatus(WILDCAMMAP_CAMERA_STATUS.SUCCESS);
-    // transform the data into an object using the cols result set
-    var object_rows = json.rows.map(row => {
-      var object_row = {}
-      row.forEach((currElement, index) => {
-        var column_name = json.columns[index]
-        object_row[column_name] = currElement
-      })
-      return object_row
-    })
-    console.log(object_rows)
-    Actions.wildcamMap.setActiveCameraData(object_rows);
+    Actions.wildcamMap.setActiveCameraData(json.rows);
   })
   .catch(err => {
     Actions.wildcamMap.setActiveCameraDataStatus(WILDCAMMAP_CAMERA_STATUS.ERROR);
@@ -388,17 +378,7 @@ Effect('wcm_getActiveCamera', (payload = {}) => {
   .then(json => {
     Actions.wildcamMap.setActiveCameraMetadataStatus(WILDCAMMAP_CAMERA_STATUS.SUCCESS);
     if (json && json.rows) {
-      // transform the data into an object using the cols result set
-      var object_rows = json.rows.map(row => {
-        var object_row = {}
-        row.forEach((currElement, index) => {
-          var column_name = json.columns[index]
-          object_row[column_name] = currElement
-        })
-        return object_row
-      })
-      console.log(object_rows)
-      Actions.wildcamMap.setActiveCameraMetadata(object_rows[0]);  //SELECT query should only return one result.
+      Actions.wildcamMap.setActiveCameraMetadata(json.rows[0]);  //SELECT query should only return one result.
     } else {
       Actions.wildcamMap.setActiveCameraMetadata(null);
     }

--- a/src/programs/darien/wildcam-darien.map-config.js
+++ b/src/programs/darien/wildcam-darien.map-config.js
@@ -18,15 +18,15 @@ const mapConfig = {
   //Connection details for the external data source.
   'database': {
     'urls': {
-      'json': '//wildcam-darien.carto.com/api/v2/sql?q={SQLQUERY}',
-      'geojson': '//wildcam-darien.carto.com/api/v2/sql?format=GeoJSON&q={SQLQUERY}',
-      'csv': '//wildcam-darien.carto.com/api/v2/sql?format=CSV&q={SQLQUERY}'
+      'json': '//localhost:8001/darien.json?sql={SQLQUERY}',
+      'geojson': '//localhost:8001/darien.geojson?sql={SQLQUERY}',
+      'csv': '//localhost:8001/darien.csv?sql={SQLQUERY}'
     },
     'queries': {
       //For each camera, show how many (filtered) results are available.
       'selectCameraCount': `
         SELECT
-          cam.*, COUNT(sbjagg.*) as count
+          cam.*, COUNT(*) as count
         FROM
           cameras AS cam
         LEFT JOIN

--- a/src/programs/darien/wildcam-darien.map-config.js
+++ b/src/programs/darien/wildcam-darien.map-config.js
@@ -18,7 +18,7 @@ const mapConfig = {
   //Connection details for the external data source.
   'database': {
     'urls': {
-      'json': '//localhost:8001/darien.json?sql={SQLQUERY}',
+      'json': '//localhost:8001/darien.json?_shape=objects&sql={SQLQUERY}',
       'geojson': '//localhost:8001/darien.geojson?sql={SQLQUERY}',
       'csv': '//localhost:8001/darien.csv?sql={SQLQUERY}'
     },

--- a/src/programs/darien/wildcam-darien.map-config.js
+++ b/src/programs/darien/wildcam-darien.map-config.js
@@ -18,9 +18,9 @@ const mapConfig = {
   //Connection details for the external data source.
   'database': {
     'urls': {
-      'json': '//localhost:8001/darien.json?_shape=objects&sql={SQLQUERY}',
-      'geojson': '//localhost:8001/darien.geojson?sql={SQLQUERY}',
-      'csv': '//localhost:8001/darien.csv?sql={SQLQUERY}'
+      'json': '//classroom-maps-api.zooniverse.org/darien.json?_shape=objects&sql={SQLQUERY}',
+      'geojson': '//classroom-maps-api.zooniverse.org/darien.geojson?sql={SQLQUERY}',
+      'csv': '//classroom-maps-api.zooniverse.org/darien.csv?sql={SQLQUERY}'
     },
     'queries': {
       //For each camera, show how many (filtered) results are available.

--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -19,7 +19,7 @@ const mapConfig = {
   //Connection details for the external data source.
   'database': {
     'urls': {
-      'json': '//localhost:8001/gorongosa.json?sql={SQLQUERY}',
+      'json': '//localhost:8001/gorongosa.json?_shape=objects&sql={SQLQUERY}',
       'geojson': '//localhost:8001/gorongosa.geojson?sql={SQLQUERY}',
       'csv': '//localhost:8001/gorongosa.csv?sql={SQLQUERY}'
     },

--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -19,9 +19,9 @@ const mapConfig = {
   //Connection details for the external data source.
   'database': {
     'urls': {
-      'json': '//localhost:8001/gorongosa.json?_shape=objects&sql={SQLQUERY}',
-      'geojson': '//localhost:8001/gorongosa.geojson?sql={SQLQUERY}',
-      'csv': '//localhost:8001/gorongosa.csv?sql={SQLQUERY}'
+      'json': '//classroom-maps-api.zooniverse.org/gorongosa.json?_shape=objects&sql={SQLQUERY}',
+      'geojson': '//classroom-maps-api.zooniverse.org/gorongosa.geojson?sql={SQLQUERY}',
+      'csv': '//classroom-maps-api.zooniverse.org/gorongosa.csv?sql={SQLQUERY}'
     },
     'queries': {
       //For each camera, show how many (filtered) results are available.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   devServer: {
     contentBase: path.join(__dirname, '/src/'),
     disableHostCheck: true,  //Allow access using custom host names, e.g. local.zooniverse.org:3998, which is necessary for testing certain API calls.
-    https: true,
+    // https: true,
     inline: true,
     stats: {
       colors: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   devServer: {
     contentBase: path.join(__dirname, '/src/'),
     disableHostCheck: true,  //Allow access using custom host names, e.g. local.zooniverse.org:3998, which is necessary for testing certain API calls.
-    // https: true,
+    https: true,
     inline: true,
     stats: {
       colors: true,


### PR DESCRIPTION
## PR Overview

Requires: https://github.com/zooniverse/labs-datasette-api/ (new API)
Context: the Carto map database requirement (for WildCam Labs) is being retired. The map database will be replaced by a Zooniverse-hosted Datasette solution.

This PR updates WildCam Gorongosa Lab and WildCam Darien Lab to integrate with the new Labs Datasette API.

Goals:
- [x] An explorer should be able to explore the map for **both Darien and Gorongosa**, e.g. http://localhost:3998/#/wildcam-darien-lab/educators/map
  - [x] An explorer should be able to see "circles" (cameras) representing results
  - [x] An explorer should be able to see "shapes" of park boundaries, etc
  - [x] An explorer should be able to use filters (Species, Habitats, etc) to narrow down results
  - [x] An explorer should be able to view the number of results (at the top of the Filter controls)
  - [x] An explorer should be able to click on a circle (camera) to see the camera's related data.
  - [x] An explorer should be able to download the results as a CSV
- [x] A teacher should be able to select a number of Subjects when creating Assignments.
  - Corollary: A teacher should be able to create Assignments. i.e. make sure to test submitting the Create Assignment action to the API!

### Status

WIP 