### PR TITLE
Hack/hotfix: temporarily hide Wildwatch Kenya from home page

### DIFF
--- a/src/components/common/Home.jsx
+++ b/src/components/common/Home.jsx
@@ -54,6 +54,12 @@ export default function Home(props) {
             const programLink = (program.metadata && program.metadata.redirect) ?
               <Anchor href={program.metadata.redirect} label="Visit Lab" /> :
               <Link to={program.slug} onClick={() => { Actions.getProgram({ programs: props.programs, param: program.slug }); }}>Enter</Link>;
+          
+            // TEMPORARY  //HACK
+            // Wildwatch Kenya has been added to the Education API for dev/preview purposes,
+            // but it's NOT ready for showtime yet!
+            // (@shaunanoordin 20210402)
+            if (program.slug === 'wildwatch-kenya-lab') return null
 
             return (
               <Tile key={program.name}>


### PR DESCRIPTION
## PR Overview

Wildwatch Kenya Lab (see https://github.com/zooniverse/classroom/pull/224) is currently in the process of development. The Program has been added to the Education API (production) since Tuesday for dev/preview purposes, but this unfortunately means that the Program is now listed on the live (!!!) Zooniverse Classrooms home page.

This PR is a quick temporary fix that prevents WWKenya from being listed on the home page.

### Status

Gonna get this merged & deployed as soon as possible.