### PR TITLE
Add `build-staging`

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -17,12 +17,12 @@ jobs:
       with:
           creds: ${{ secrets.AZURE_STATIC_SITES }}
 
-    - name: Node.js build
+    - name: Node.js build-staging
       uses: actions/setup-node@v1
       with:
         node-version: '14.x'
     - run: npm install
-    - run: npm run build
+    - run: npm run build-staging
 
     - name: Upload to blob storage
       uses: azure/CLI@v1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "export NODE_ENV=development; BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js enzyme-setup.js $(find src -name *.spec.jsx) || true",
     "eslint": "eslint .",
-    "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p"
+    "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
+    "build-staging": "export BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.config.js -p"
   },
   "engines": {
     "node": ">=14",

--- a/src/containers/layout/AuthContainer.jsx
+++ b/src/containers/layout/AuthContainer.jsx
@@ -35,7 +35,7 @@ export class AuthContainer extends React.Component {
   loginWithGoogle() {
     let googleUrl = 'https://panoptes.zooniverse.org/users/auth/google_oauth2';
 
-    if (env === 'development') {
+    if (env === 'staging' || env === 'development') {
       googleUrl = 'https://panoptes-staging.zooniverse.org/users/auth/google_oauth2';
     }
 


### PR DESCRIPTION
## PR Overview

This PR adds the `build-staging` script, so our [staging website](https://classroom.preview.zooniverse.org/) uses Staging instead of Production data.

- Currently, https://classroom.preview.zooniverse.org/ connects to Production because there's only one `build` script, and that's for prod.
- Note that the staging website is auto-deployed via Github Actions

### Status

Code ready to review, but mind you, I can't seem to get `npm run build-staging` (nor `npm run build`) on my machine for self testing, due to a bunch of configuration shenanigans. Sigh, don't ask, I keep getting Python errors even though this shouldn't be using any Python. (`npm run start` works fine though, so I know the website code is working OK, it's my local machine config that's borked.)

@camallen Can you please take a look at this? Especially the line...

```
"build-staging": "export BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.config.js -p"
```

...I'm not sure if that should be webpack.production.config.js , because as I said, I can't compile locally. 😢 