### PR TITLE
Fix build-staging for Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js enzyme-setup.js $(find src -name *.spec.jsx) || true",
     "eslint": "eslint .",
     "build": "export NODE_ENV=production; BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js",
-    "build-staging": "export NODE_ENV=staging; BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.config.js"
+    "build-staging": "export NODE_ENV=development; BABEL_ENV=development; check-engines && check-dependencies && webpack --config webpack.config.js"
   },
   "engines": {
     "node": ">=14",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js enzyme-setup.js $(find src -name *.spec.jsx) || true",
     "eslint": "eslint .",
     "build": "export NODE_ENV=production; BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js",
-    "build-staging": "export NODE_ENV=staging; export BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.production.config.js -p"
+    "build-staging": "export NODE_ENV=staging; BABEL_ENV=staging; check-engines && check-dependencies && webpack --config webpack.config.js"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
## PR Overview

PR #249 failed in its intent - `npm run build-staging` was failing. PR #248 should have been merged first, since there were essential Webpack 5 upgrades. This PR attempts to fix 249.