### PR TITLE
Remove azcliversion from github actions

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Upload to blob storage
       uses: azure/CLI@v1
       with:
-        azcliversion: 2.29.2
         inlineScript: |
             az storage blob upload-batch \
               --account-name zooniversestatic \

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Upload to blob storage
       uses: azure/CLI@v1
       with:
-        azcliversion: 2.29.2
         inlineScript: |
             az storage blob upload-batch \
               --account-name zooniversestatic \


### PR DESCRIPTION
Per azure-cli/issues/20154, `azcliversion` should be omitted so defaults to latest, or set to latest. For consistency with other Zooniverse repos this PR removes `azcliversion: 2.29.2`.