### PR TITLE
Enforce acceptable languages for WildCam Lab Programs

### DIFF
--- a/src/lib/zooniversal-translator.js
+++ b/src/lib/zooniversal-translator.js
@@ -15,12 +15,12 @@ This documentation is accurate as of Stardate 2017.240
 ********************************************************************************
  */
 
-import EnglishTranslations from './zooniversal-translator.en.js'; 
-import SpanishTranslations from './zooniversal-translator.es.js'; 
+import EnglishTranslations from './zooniversal-translator.en.js';
+import SpanishTranslations from './zooniversal-translator.es.js';
 
 export function ZooTran(text) {
   const translations = ZooTranGetTranslationsObject();
-  
+
   return (translations && translations[text])
     ? translations[text]
     : text;
@@ -45,4 +45,20 @@ export function ZooTranGetTranslationsObject() {
   const lang = ZooTranGetLanguage();
   if (lang === 'es') return SpanishTranslations;
   return EnglishTranslations;
+}
+
+/*
+Checks if ZooTran is using a valid language for the current Program. If not,
+reset to a valid language, and then reload the page.
+ */
+export function ZooTranCheckForValidLanguage(acceptableLanguages = ['en']) {
+  const lang = ZooTranGetLanguage();  // Note: lang can be null or ''
+  if (lang && !acceptableLanguages.includes(lang)) {
+    ZooTranSetLanguage('');
+    setTimeout(() => { window.location.reload() }, 100);
+    // Using timeout + reload is a crude but effective solution. A more elegant
+    // solution would be to rework the translation system entirely, using
+    // `counterpart` or a similar library to replace the Zooniversal Translator
+    // @shaun.a.noordin 2022.01.07
+  }
 }

--- a/src/programs/darien/DarienProgram.jsx
+++ b/src/programs/darien/DarienProgram.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { Switch, Route, Redirect } from 'react-router-dom';
-import { ZooTranSetLanguage, ZooTranGetLanguage } from '../../lib/zooniversal-translator'
+import { ZooTranSetLanguage, ZooTranCheckForValidLanguage } from '../../lib/zooniversal-translator';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
@@ -44,8 +44,11 @@ import GenericStatusPage from '../../components/common/GenericStatusPage';
 class DarienProgram extends React.Component {
   constructor() {
     super();
+
+    // Set acceptable languages/locales for this program
+    ZooTranCheckForValidLanguage(['en', 'es']);
   }
-  
+
   componentWillReceiveProps(props = this.props) {
     //Register the connection between the WildCam Classrooms and the WildCam Maps.
     Actions.wildcamMap.setWccWcmMapPath(`${props.match.url}/educators/map`);
@@ -53,7 +56,7 @@ class DarienProgram extends React.Component {
 
   render() {
     const props = this.props;
-    
+
     if (!props.initialised) {  //User status unknown: wait.
       return (<GenericStatusPage status="fetching" message="Loading..." />);
     } else if (!props.selectedProgram) {  //Anomaly: program status not set.
@@ -72,12 +75,12 @@ class DarienProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/ecology`} component={DarienInfoEcology} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/resources`} component={DarienInfoResources} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={DarienInfoAssignmentsGuide} />
-              
+
               <Route exact path={`${props.match.url}/educators/intro`} component={DarienEducatorsIntro} />
               {/* //HACK: The following redirect avoids a weird bug where, if you go to a Classroom, then an Assignment, then press Back, then Back again, you end up in the /educators/classrooms URL. */}
               <Redirect exact from={`${props.match.url}/educators/classrooms`} to={`${props.match.url}/educators`}/>
               <Route path={`${props.match.url}/educators`} component={DarienEducators} />
-              
+
               <Route exact path={`${props.match.url}/students/intro`} component={DarienStudentsIntro} />
               <Route path={`${props.match.url}/students`} component={DarienStudents} />
 
@@ -98,7 +101,7 @@ class DarienProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/ecology`} component={DarienInfoEcology} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/resources`} component={DarienInfoResources} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={DarienInfoAssignmentsGuide} />
-              
+
               <Route path={`${props.match.url}/educators`} component={Status401} />
               <Route path={`${props.match.url}/students`} component={Status401} />
 
@@ -110,10 +113,10 @@ class DarienProgram extends React.Component {
       }
     }
   }
-  
+
   renderNavi() {
     const props = this.props;
-    
+
     return (
       <Switch>
         <Route path={`${props.match.url}/educators`} component={DarienNaviForEducators} />
@@ -123,10 +126,10 @@ class DarienProgram extends React.Component {
       </Switch>
     );
   }
-  
+
   renderLanguage() {
     const props = this.props;
-    
+
     return (
       <Section
         className="program-language-selection"

--- a/src/programs/gorongosa/GorongosaProgram.jsx
+++ b/src/programs/gorongosa/GorongosaProgram.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { Switch, Route, Redirect } from 'react-router-dom';
+import { ZooTranCheckForValidLanguage } from '../../lib/zooniversal-translator';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
@@ -43,8 +44,11 @@ import GenericStatusPage from '../../components/common/GenericStatusPage';
 class GorongosaProgram extends React.Component {
   constructor() {
     super();
+
+    // Set acceptable languages/locales for this program
+    ZooTranCheckForValidLanguage(['en']);
   }
-  
+
   componentWillReceiveProps(props = this.props) {
     //Register the connection between the WildCam Classrooms and the WildCam Maps.
     Actions.wildcamMap.setWccWcmMapPath(`${props.match.url}/educators/map`);
@@ -52,7 +56,7 @@ class GorongosaProgram extends React.Component {
 
   render() {
     const props = this.props;
-    
+
     if (!props.initialised) {  //User status unknown: wait.
       return (<GenericStatusPage status="fetching" message="Loading..." />);
     } else if (!props.selectedProgram) {  //Anomaly: program status not set.
@@ -71,12 +75,12 @@ class GorongosaProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/ecology`} component={GorongosaInfoEcology} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/resources`} component={GorongosaInfoResources} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={GorongosaInfoAssignmentsGuide} />
-              
+
               <Route exact path={`${props.match.url}/educators/intro`} component={GorongosaEducatorsIntro} />
               {/* //HACK: The following redirect avoids a weird bug where, if you go to a Classroom, then an Assignment, then press Back, then Back again, you end up in the /educators/classrooms URL. */}
               <Redirect exact from={`${props.match.url}/educators/classrooms`} to={`${props.match.url}/educators`}/>
               <Route path={`${props.match.url}/educators`} component={GorongosaEducators} />
-              
+
               <Route exact path={`${props.match.url}/students/intro`} component={GorongosaStudentsIntro} />
               <Route path={`${props.match.url}/students`} component={GorongosaStudents} />
 
@@ -96,7 +100,7 @@ class GorongosaProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/ecology`} component={GorongosaInfoEcology} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/resources`} component={GorongosaInfoResources} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={GorongosaInfoAssignmentsGuide} />
-              
+
               <Route path={`${props.match.url}/educators`} component={Status401} />
               <Route path={`${props.match.url}/students`} component={Status401} />
 
@@ -107,10 +111,10 @@ class GorongosaProgram extends React.Component {
       }
     }
   }
-  
+
   renderNavi() {
     const props = this.props;
-    
+
     return (
       <Switch>
         <Route path={`${props.match.url}/educators`} component={GorongosaNaviForEducators} />

--- a/src/programs/kenya/KenyaProgram.jsx
+++ b/src/programs/kenya/KenyaProgram.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { Switch, Route, Redirect } from 'react-router-dom';
+import { ZooTranCheckForValidLanguage } from '../../lib/zooniversal-translator';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
@@ -42,8 +43,11 @@ import GenericStatusPage from '../../components/common/GenericStatusPage';
 class KenyaProgram extends React.Component {
   constructor() {
     super();
+
+    // Set acceptable languages/locales for this program
+    ZooTranCheckForValidLanguage(['en']);
   }
-  
+
   componentWillReceiveProps(props = this.props) {
     //Register the connection between the WildCam Classrooms and the WildCam Maps.
     Actions.wildcamMap.setWccWcmMapPath(`${props.match.url}/educators/map`);
@@ -51,7 +55,7 @@ class KenyaProgram extends React.Component {
 
   render() {
     const props = this.props;
-    
+
     if (!props.initialised) {  //User status unknown: wait.
       return (<GenericStatusPage status="fetching" message="Loading..." />);
     } else if (!props.selectedProgram) {  //Anomaly: program status not set.
@@ -69,12 +73,12 @@ class KenyaProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/data-guide`} component={KenyaInfoCSV} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/project-overview`} component={KenyaInfoProjectOverview} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={KenyaInfoAssignmentsGuide} />
-              
+
               <Route exact path={`${props.match.url}/educators/intro`} component={KenyaEducatorsIntro} />
               {/* //HACK: The following redirect avoids a weird bug where, if you go to a Classroom, then an Assignment, then press Back, then Back again, you end up in the /educators/classrooms URL. */}
               <Redirect exact from={`${props.match.url}/educators/classrooms`} to={`${props.match.url}/educators`}/>
               <Route path={`${props.match.url}/educators`} component={KenyaEducators} />
-              
+
               <Route exact path={`${props.match.url}/students/intro`} component={KenyaStudentsIntro} />
               <Route path={`${props.match.url}/students`} component={KenyaStudents} />
 
@@ -93,7 +97,7 @@ class KenyaProgram extends React.Component {
               <Route exact path={`${props.match.url}/(educators|students|explorers)/data-guide`} component={KenyaInfoCSV} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/project-overview`} component={KenyaInfoProjectOverview} />
               <Route exact path={`${props.match.url}/(educators|students|explorers)/assignments-guide`} component={KenyaInfoAssignmentsGuide} />
-              
+
               <Route path={`${props.match.url}/educators`} component={Status401} />
               <Route path={`${props.match.url}/students`} component={Status401} />
 
@@ -104,10 +108,10 @@ class KenyaProgram extends React.Component {
       }
     }
   }
-  
+
   renderNavi() {
     const props = this.props;
-    
+
     return (
       <Switch>
         <Route path={`${props.match.url}/educators`} component={KenyaNaviForEducators} />


### PR DESCRIPTION
## PR Overview

Fixes #255

This PR fixes an issue where a use can choose a language in WildCam Lab Program X, then that language choice would persist in WildCam Lab Program Y EVEN IF Program Y doesn't support that language

- With this PR, each WCL Program has a list of _acceptable languages_ (Kenya/Gorongosa: English/default only. Daríen: English/default or Spanish)
- When a user loads a WCL Program page but has an _unacceptable_ language stored in their settings, the settings will be reset and the page will _reload_

This approach is crude, but the better alternative (replacing the Zooniversal Translator hack with the proper `counterpart` library) would take a bit more time investment.

### Status

Merging, go