### PR TITLE
Build with node 16.

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Node.js build
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
-    - run: npm install
+        node-version: '16.x'
+    - run: npm ci
     - run: npm run build
 
     - name: Upload to blob storage

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Node.js build-staging
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
-    - run: npm install
+        node-version: '16.x'
+    - run: npm ci
     - run: npm run build-staging
 
     - name: Upload to blob storage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-staging": "export NODE_ENV=development; BABEL_ENV=development; check-engines && check-dependencies && webpack --config webpack.config.js"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=16",
     "npm": ">=7"
   },
   "author": "Zooniverse",


### PR DESCRIPTION
#259 bumped the npm version to 7. This upgrades Node to match.

Builds are broken at the moment because Node 14 bundles with npm 6. This should fix that by building with Node 16/npm 8.