### PR TITLE
Remove `query-string`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "path-browserify": "~1.0.1",
         "prop-types": "~15.8.1",
         "punycode": "~2.1.1",
-        "query-string": "~5.0.0",
         "react": "~16.14.0",
         "react-copy-to-clipboard": "~5.1.0",
         "react-dom": "~16.14.0",
@@ -5090,6 +5089,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -13219,6 +13219,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
       "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
+      "dev": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -15177,6 +15178,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21342,7 +21344,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress": {
       "version": "4.2.1",
@@ -27535,6 +27538,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
       "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
+      "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -29112,7 +29116,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "path-browserify": "~1.0.1",
     "prop-types": "~15.8.1",
     "punycode": "~2.1.1",
-    "query-string": "~5.0.0",
     "react": "~16.14.0",
     "react-copy-to-clipboard": "~5.1.0",
     "react-dom": "~16.14.0",

--- a/src/containers/common/JoinPageContainer.jsx
+++ b/src/containers/common/JoinPageContainer.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
-import queryString from 'query-string';
 
 import JoinPage from '../../components/common/JoinPage';
 import {
@@ -39,7 +38,8 @@ export class JoinPageContainer extends React.Component {
 
   joinClassroom(props, program) {
     const classroomId = props.match.params.classroomId;
-    const joinToken = queryString.parse(props.location.search);
+    const searchParams = new URLSearchParams(props.location.search)
+    const joinToken = searchParams.get('joinToken');
     const selectedProgram = program || props.selectedProgram;
 
     Actions.joinClassroom({ classroomId, joinToken: joinToken.token })


### PR DESCRIPTION
- Remove `query-string`.
- Use the `URLSearchParams` API to get join tokens for classrooms.

Towards #327.