### PR TITLE
Use production builds for CI

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -13,4 +13,4 @@ jobs:
       commit_id: ${{ github.sha }}
       node_version: '16.x'
       output: 'dist'
-      script: '_build-staging'
+      script: 'build'

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -17,7 +17,7 @@ jobs:
       commit_id: ${{ github.sha }}
       node_version: '16.x'
       output: 'dist'
-      script: '_build-production'
+      script: 'build'
   deploy:
     name: Deploy production
     uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -17,7 +17,7 @@ jobs:
       commit_id: ${{ github.sha }}
       node_version: '16.x'
       output: 'dist'
-      script: '_build-staging'
+      script: 'build'
   deploy:
     name: Deploy staging
     uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "start": "export NODE_ENV=development; BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack serve --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js enzyme-setup.js $(find src -name *.spec.jsx) || true",
     "eslint": "eslint .",
-    "_build-production": "export NODE_ENV=production; npm run _build",
-    "_build-staging": "export NODE_ENV=development; npm run _build",
-    "_build": "BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js"
+    "build": "BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js"
   },
   "engines": {
     "node": ">=16",


### PR DESCRIPTION
All CI and deploy builds should use `NODE_ENV=production` (see abab70e093e1abd53b09c489e37678293d8c11c3.)

Fixes this warning.
```log
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'
```