### PR TITLE
Fix Redux store context for Layer

### DIFF
--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -7,7 +7,6 @@ import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
 import Label from 'grommet/components/Label';
-import Layer from 'grommet/components/Layer';
 import List from 'grommet/components/List';
 import ListItem from 'grommet/components/ListItem';
 import Paragraph from 'grommet/components/Paragraph';
@@ -85,9 +84,8 @@ const ClassroomEditor = (props) => {
         </ConfirmationDialog>
 
         {props.showForm &&
-          <Layer closer={true} onClose={props.toggleFormVisibility}>
-            <ClassroomFormContainer heading="Edit Classroom" submitLabel="Update" />
-          </Layer>}
+          <ClassroomFormContainer heading="Edit Classroom" submitLabel="Update" />
+        }
 
         <Box
           align="center"

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -6,7 +6,6 @@ import Box from 'grommet/components/Box';
 import Paragraph from 'grommet/components/Paragraph';
 import Button from 'grommet/components/Button';
 import Spinning from 'grommet/components/icons/Spinning';
-import Layer from 'grommet/components/Layer';
 
 import {
   CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
@@ -26,13 +25,12 @@ const ClassroomsManager = (props) => {
           type="button"
           primary={true}
           label="Create New Classroom"
-          onClick={props.toggleFormVisibility}
+          onClick={Actions.classrooms.toggleFormVisibility}
         />
       </Box>
       {props.showForm &&
-        <Layer closer={true} onClose={props.toggleFormVisibility}>
-          <ClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
-        </Layer>}
+        <ClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
+      }
       {(props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.FETCHING) &&
         <Box align="center"><Spinning /></Box>}
       {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS &&
@@ -48,7 +46,6 @@ const ClassroomsManager = (props) => {
 ClassroomsManager.defaultProps = {
   classroomInstructions: 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.',
   showForm: false,
-  toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
   ...CLASSROOMS_INITIAL_STATE
 };
 

--- a/src/containers/assignments/AssignmentFormContainer.jsx
+++ b/src/containers/assignments/AssignmentFormContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
+import Layer from 'grommet/components/Layer';
 
 import AssignmentForm from '../../components/assignments/AssignmentForm';
 import {
@@ -116,15 +117,17 @@ export class AssignmentFormContainer extends React.Component {
 
   render() {
     return (
-      <AssignmentForm
-        heading={this.props.heading}
-        fields={this.props.formFields}
-        onChange={this.onChange}
-        onChangeDate={this.onChangeDate}
-        onSubmit={this.onSubmit}
-        students={this.props.selectedClassroomToLink ? this.props.selectedClassroomToLink.students : []}
-        submitLabel={this.props.submitLabel}
-      />
+      <Layer closer={true} onClose={Actions.assignments.toggleFormVisibility}>
+        <AssignmentForm
+          heading={this.props.heading}
+          fields={this.props.formFields}
+          onChange={this.onChange}
+          onChangeDate={this.onChangeDate}
+          onSubmit={this.onSubmit}
+          students={this.props.selectedClassroomToLink ? this.props.selectedClassroomToLink.students : []}
+          submitLabel={this.props.submitLabel}
+        />
+      </Layer>
     );
   }
 }

--- a/src/containers/assignments/AssignmentFormDialog.jsx
+++ b/src/containers/assignments/AssignmentFormDialog.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
-import Layer from 'grommet/components/Layer';
 
 import AssignmentFormContainer from './AssignmentFormContainer';
 import {
@@ -15,9 +14,7 @@ export const AssignmentFormDialog = (props) => {
 
   if (props.showForm) {
     return (
-      <Layer closer={true} onClose={toggleForm}>
-        <AssignmentFormContainer heading={props.heading} submitLabel={props.submitLabel} onSubmit={toggleForm} />
-      </Layer>
+      <AssignmentFormContainer heading={props.heading} submitLabel={props.submitLabel} onSubmit={toggleForm} />
     );
   }
 

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
+import Layer from 'grommet/components/Layer';
 
 import ClassroomForm from '../../components/classrooms/ClassroomForm';
 import {
@@ -111,14 +112,16 @@ export class ClassroomFormContainer extends React.Component {
 
   render() {
     return (
-      <ClassroomForm
-        classroomsStatus={this.props.classroomsStatus}
-        heading={this.props.heading}
-        formFields={this.props.formFields}
-        onChange={this.onChange}
-        onSubmit={this.onSubmit}
-        submitLabel={this.props.submitLabel}
-      />
+      <Layer closer={true} onClose={Actions.classrooms.toggleFormVisibility}>
+        <ClassroomForm
+          classroomsStatus={this.props.classroomsStatus}
+          heading={this.props.heading}
+          formFields={this.props.formFields}
+          onChange={this.onChange}
+          onSubmit={this.onSubmit}
+          submitLabel={this.props.submitLabel}
+        />
+      </Layer>
     );
   }
 }


### PR DESCRIPTION
Wrap the connected assignment form and classroom form in `Layer`. This makes sure that the Redux store context is passed down correctly to the layer contents.

Closes #325.