### PR TITLE
Fix joining a classroom

### DIFF
--- a/src/containers/common/JoinPageContainer.jsx
+++ b/src/containers/common/JoinPageContainer.jsx
@@ -38,11 +38,11 @@ export class JoinPageContainer extends React.Component {
 
   joinClassroom(props, program) {
     const classroomId = props.match.params.classroomId;
-    const searchParams = new URLSearchParams(props.location.search)
-    const joinToken = searchParams.get('joinToken');
+    const searchParams = new URLSearchParams(props.location.search);
+    const joinToken = searchParams.get('token');
     const selectedProgram = program || props.selectedProgram;
 
-    Actions.joinClassroom({ classroomId, joinToken: joinToken.token })
+    Actions.joinClassroom({ classroomId, joinToken })
       .then(() => {
         if (props.programsStatus === PROGRAMS_STATUS.SUCCESS &&
             (selectedProgram && selectedProgram.metadata && selectedProgram.metadata.redirectOnJoin)) {


### PR DESCRIPTION
The URL parameter for joining a classroom is `token`, not `joinToken`, but the API parameter is `joinToken`.

At the moment, joining a classroom will error with `joinToken is null`.