### PR TITLE
Define NODE_ENV for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "export NODE_ENV=development; BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack serve --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js enzyme-setup.js $(find src -name *.spec.jsx) || true",
     "eslint": "eslint .",
-    "build": "BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js"
+    "build": "export NODE_ENV=production; BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js"
   },
   "engines": {
     "node": ">=16",


### PR DESCRIPTION
Per https://github.com/zooniverse/classroom/blob/master/src/lib/config.js environment is defaulting to `staging` for `build` script.

This PR defines the node environment to `production` for the `build` script. 
This will change the staging classroom site to point to the production Panoptes database. Is that what we want or shuold we revisit #330 and #323?