### PR TITLE
Wildwatch Kenya: fix 'year' and 'month' mistakenly removed from selectAllSubjects

### DIFF
--- a/src/programs/kenya/wildwatch-kenya.classroom-config.js
+++ b/src/programs/kenya/wildwatch-kenya.classroom-config.js
@@ -110,6 +110,8 @@ function combineWithSubjectMetadata (classifications = []) {
             camera: '',
             //subject_id: ''  // No, leave this alone
             location: '',
+            month: '',
+            year: '',
             'data.choice': '',
             'data.choice_count': '',
             'data.total_vote_count': '',

--- a/src/programs/kenya/wildwatch-kenya.map-config.js
+++ b/src/programs/kenya/wildwatch-kenya.map-config.js
@@ -112,7 +112,7 @@ const mapConfig = {
       //Get all subjects, with camera data.
       'selectAllSubjects': `
         SELECT
-          sbj.subject_id, sbj.camera, cam.longitude, sbj.location, cam.latitude, cam.season
+          sbj.subject_id, sbj.camera, cam.longitude, sbj.month, sbj.year, sbj.location, cam.latitude, cam.season
         FROM
           subjects AS sbj
         LEFT JOIN


### PR DESCRIPTION
## PR Overview

Follows #351

In that PR, I mistakenly removed `sbj.month` and `sbj.year` from the `selectAllSubjects` SQL query, because I thought those columns didn't exist in the database. Well, they do! Sorry about that, columns.