### PR TITLE
Update Instructors Guide Link

### DIFF
--- a/src/components/astro/AstroHome.jsx
+++ b/src/components/astro/AstroHome.jsx
@@ -68,7 +68,7 @@ const AstroHome = (props) => {
           justify="center"
         >
           <Box className="astro-home__guide" align="center" direction="row" size="xxlarge">
-          <Button className="button--secondary" href="https://drive.google.com/drive/folders/1Kr3MxJoPxcwOlJN2FMn-gbjNNneOqX5i" type="button" label="Instructors Guide" target="_blank" rel="noopener noreferrer" />
+          <Button className="button--secondary" href="https://drive.google.com/drive/folders/1HS-yV9EUyMTjvoxiDasKpQINAIBJX_d6?usp=sharing" type="button" label="Instructors Guide" target="_blank" rel="noopener noreferrer" />
             <Paragraph align="start">
                 Instructors Guide: This provides you with a suggested timeline, lesson plans and student instructions for the class activities that will  guide the students in how to use the tools and the research project where students demonstrate the skills they have learned.
             </Paragraph>


### PR DESCRIPTION
Update Drive link for Instructors Guide to new, post-GSuiteMigration URL (https://drive.google.com/drive/folders/1HS-yV9EUyMTjvoxiDasKpQINAIBJX_d6?usp=sharing).