### PR TITLE
Update panoptes-client to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "grommet": "~1.13.0",
         "jumpstate": "~2.2.2",
         "leaflet": "1.8.0",
-        "panoptes-client": "~4.0.0",
+        "panoptes-client": "~4.1.0",
         "papaparse": "~5.3.2",
         "path-browserify": "~1.0.1",
         "prop-types": "~15.8.1",
@@ -12689,9 +12689,9 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "dependencies": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
@@ -27147,9 +27147,9 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "requires": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grommet": "~1.13.0",
     "jumpstate": "~2.2.2",
     "leaflet": "1.8.0",
-    "panoptes-client": "~4.0.0",
+    "panoptes-client": "~4.1.0",
     "papaparse": "~5.3.2",
     "path-browserify": "~1.0.1",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
## PR Overview

This is a dependency bump for PJC, mostly for security reasons.

Localhost testing looks good - I can sign in and view my classrooms