### PR TITLE
Zooniverse In Schools/Astro 101 - Classroom Editor shows all Assignments

### DIFF
--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -67,7 +67,6 @@ const ClassroomEditor = (props) => {
     );
   }
 
-
   if (props.selectedClassroom && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) {
     return (
       <Box
@@ -167,24 +166,17 @@ const ClassroomEditor = (props) => {
               <th id="student-name" scope="col">
                 <span className="headers__header">Student Name/Zooniverse ID</span>
               </th>
-              <th id="assignment-galaxy" scope="col">
-                <Button
-                  className="headers__header"
-                  onClick={props.toggleCountView.bind(null, i2aAssignmentNames.galaxy)}
-                  plain={true}
-                >
-                  {i2aAssignmentNames.galaxy}
-                </Button>
-              </th>
-              <th id="assignment-hubble" scope="col" >
-                <Button
-                  className="headers__header"
-                  onClick={props.toggleCountView.bind(null, i2aAssignmentNames.hubble)}
-                  plain={true}
-                >
-                  {i2aAssignmentNames.hubble}
-                </Button>
-              </th>
+              {assignments.map(ass => (
+                <th id={`assignment-${ass.id}`} scope="col">
+                  <Button
+                    className="headers__header"
+                    onClick={props.toggleCountView.bind(null)}
+                    plain={true}
+                  >
+                    {ass.name}
+                  </Button>
+                </th>
+              ))}
               <th id="student-remove" scope="col">
                 <span className="headers__header">Remove Student</span>
               </th>
@@ -235,8 +227,33 @@ const ClassroomEditor = (props) => {
                       ? <span>{student.zooniverseDisplayName}</span>
                       : <span className="secondary">{student.zooniverseLogin}</span> }
                   </td>
+                  {assignments.map((ass, i) => {
+                    const studentData = ass.studentAssignmentsData.filter(data => data.attributes.student_user_id.toString() === student.id)
+                    const studentCount = studentData[0]?.attributes.classifications_count || 0
+                    const targetCount = +ass.metadata.classifications_target
+                    const resultsAsPercentage = (studentCount / targetCount).toFixed(2) * 100
+                    const resultsAsWholeNumbers = `${studentCount} / ${targetCount}`
+
+                    return (
+                      <td
+                        headers={`assignment-${ass.id}`}
+                        key={`assignment-${ass.id}-${i}`}
+                      >
+                        {props.showCounts ? resultsAsWholeNumbers : `${resultsAsPercentage <= 100 ? resultsAsPercentage : 100}%`}
+                      </td>
+                    )
+
+                    /*return (
+                      <td headers={`assignment-${ass.id}`}>
+                        {props.showCounts ? resultsAsWholeNumbers : `${resultsAsPercentage <= 100 ? resultsAsPercentage : 100}%`}
+                      </td>
+                    )*/
+                  })}
+
+                  {/*
                   <td headers="assignment-galaxy">{props.showCounts ? galaxyCount : `${galaxyPercentage <= 100 ? galaxyPercentage : 100}%`}</td>
                   <td headers="assignment-hubble">{props.showCounts ? hubbleCount : `${hubblePercentage <= 100 ? hubblePercentage : 100}%`}</td>
+                  */}
                   <td headers="student-remove">
                     <Button
                       className="manager-table__button--delete"

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -235,8 +235,8 @@ const ClassroomEditor = (props) => {
                       ? <span>{student.zooniverseDisplayName}</span>
                       : <span className="secondary">{student.zooniverseLogin}</span> }
                   </td>
-                  <td headers="assignment-galaxy">{props.showCounts.galaxy ? galaxyCount : `${galaxyPercentage <= 100 ? galaxyPercentage : 100}%`}</td>
-                  <td headers="assignment-hubble">{props.showCounts.hubble ? hubbleCount : `${hubblePercentage <= 100 ? hubblePercentage : 100}%`}</td>
+                  <td headers="assignment-galaxy">{props.showCounts ? galaxyCount : `${galaxyPercentage <= 100 ? galaxyPercentage : 100}%`}</td>
+                  <td headers="assignment-hubble">{props.showCounts ? hubbleCount : `${hubblePercentage <= 100 ? hubblePercentage : 100}%`}</td>
                   <td headers="student-remove">
                     <Button
                       className="manager-table__button--delete"
@@ -264,10 +264,7 @@ ClassroomEditor.defaultProps = {
   removeStudentFromClassroom: () => {},
   //----------------
   showConfirmationDialog: false,
-  showCounts: {
-    galaxy: false,
-    hubble: false
-  },
+  showCounts: false,
   showForm: false,
   toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
   //----------------
@@ -281,10 +278,7 @@ ClassroomEditor.propTypes = {
   removeStudentFromClassroom: PropTypes.func,
   //----------------
   showConfirmationDialog: PropTypes.bool,
-  showCounts: PropTypes.shape({
-    galaxy: PropTypes.bool,
-    hubble: PropTypes.bool
-  }),
+  showCounts: PropTypes.bool,
   showForm: PropTypes.bool,
   toggleFormVisibility: PropTypes.func,
   //----------------

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -20,10 +20,7 @@ export class ClassroomEditorContainer extends React.Component {
     super(props);
 
     this.state = {
-      showCounts: {
-        galaxy: false,
-        hubble: false
-      },
+      showCounts: true,
       showConfirmationDialog: false,
       studentToDelete: {
         classroomId: null,
@@ -132,16 +129,10 @@ export class ClassroomEditorContainer extends React.Component {
     });
   }
 
-  toggleCountView(assignment) {
-    if (assignment === i2aAssignmentNames.galaxy) {
-      this.setState((prevState) => {
-        return { showCounts: { galaxy: !prevState.showCounts.galaxy, hubble: prevState.showCounts.hubble } };
-      });
-    } else if (assignment === i2aAssignmentNames.hubble) {
-      this.setState((prevState) => {
-        return { showCounts: { galaxy: prevState.showCounts.galaxy, hubble: !prevState.showCounts.hubble } };
-      });
-    }
+  toggleCountView() {
+    this.setState((prevState) => {
+      return { showCounts: !prevState.showCounts }
+    })
   }
 
   render() {


### PR DESCRIPTION
## PR Overview

Programs: Zooniverse In Schools, Astro 101

This PR updates Astro 101's Classroom Editor [(example)](https://local.zooniverse.org:3998/#/astro-101-with-galaxy-zoo/educators/classrooms/467) so that it's "student progress table" shows _all available assignments,_ not just GZ and Hubble.

- Previously, Astro 101's Classroom Editor was hardcoded to only display 2 assignments: Galaxy Zoo and Hubble. ZIS adds a third assignment - also title _Zooniverse In Schools_ - which needs to be displayed.
- UI change: exactly what I just said
- Behaviour change:
  - previously, each assignment's progress count could _individually_ switch its student progress display between percentage complete (e.g. 33%) or whole numbers (e.g. 6 / 9 ) by clicking on the assignment name in the table header. Now, clicking on ANY assignment name will switch the display for EVERY assignment. This is just to make things simpler.
  - previously, each assignment's student progress display defaulted to percentage. Now, the default is whole numbers. (I just think it seems clearer.)

Astro 101's classrooms were previously hardcoded with static/pre-known assignments because there was a heavy emphasis on presenting the assignments in a specific order. I see no strong reason to continue with this, as we modify Classrooms for the present-day requirements. 