### PR TITLE
Uninstall express (unused)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "eslint-plugin-jsx-a11y": "~6.8.0",
         "eslint-plugin-react": "~7.33.2",
         "eslint-plugin-react-hooks": "~4.6.0",
-        "express": "~4.19.2",
         "html-webpack-plugin": "~5.6.3",
         "jsdom": "~23.0.1",
         "mini-css-extract-plugin": "~2.7.6",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "eslint-plugin-jsx-a11y": "~6.8.0",
     "eslint-plugin-react": "~7.33.2",
     "eslint-plugin-react-hooks": "~4.6.0",
-    "express": "~4.19.2",
     "html-webpack-plugin": "~5.6.3",
     "jsdom": "~23.0.1",
     "mini-css-extract-plugin": "~2.7.6",


### PR DESCRIPTION
This PR removes `express`, which appears unused and replaced with webpack-dev-server